### PR TITLE
User friendly collection routes

### DIFF
--- a/src/lib/hooks.ts
+++ b/src/lib/hooks.ts
@@ -64,7 +64,7 @@ export function userFriendlyRouteToAddress(
   chainId: ChainId | string,
 ) {
 
-  if (formattedAddress?.match(/0x/)) {
+  if (formattedAddress?.match(/^0x/)) {
     return formattedAddress
   }
 

--- a/src/lib/hooks.ts
+++ b/src/lib/hooks.ts
@@ -70,22 +70,21 @@ export function userFriendlyRouteToAddress(
 
   if (!collections?.[chainId]) {
     return formattedAddress
-  } else {
-
-    const tokenAddress = collections?.[chainId]?.find(t => formattedAddress === t.route)
-    return !!tokenAddress?.address
-      ? tokenAddress.address
-      : formattedAddress
   }
+
+  const tokenAddress = collections?.[chainId]?.find(t => formattedAddress === t.route)
+  return !!tokenAddress?.address
+    ? tokenAddress.address
+    : formattedAddress
 }
 
-export interface CollectionItem {
+export type CollectionItem = {
   name: string
   route: string
   address: string
 }
 
-export interface Collections {
+export type Collections = {
   [key: number]: CollectionItem[]
 }
 

--- a/src/lib/hooks.ts
+++ b/src/lib/hooks.ts
@@ -72,7 +72,7 @@ export function userFriendlyRouteToAddress(
     return formattedAddress
   } else {
 
-    let tokenAddress = collections?.[chainId]?.find(t => formattedAddress === t.route)
+    const tokenAddress = collections?.[chainId]?.find(t => formattedAddress === t.route)
     return !!tokenAddress?.address
       ? tokenAddress.address
       : formattedAddress

--- a/src/lib/hooks.ts
+++ b/src/lib/hooks.ts
@@ -61,7 +61,7 @@ export function useChainId() {
 
 export function userFriendlyRouteToAddress(
   formattedAddress: string,
-  chainId: ChainId | string,
+  chainId: ChainId,
 ) {
 
   if (formattedAddress?.match(/^0x/)) {
@@ -81,7 +81,7 @@ export function userFriendlyRouteToAddress(
 
 export interface CollectionItem {
   name: string
-  route?: string
+  route: string
   address: string
 }
 

--- a/src/lib/hooks.ts
+++ b/src/lib/hooks.ts
@@ -61,7 +61,7 @@ export function useChainId() {
 
 export function userFriendlyRouteToAddress(
   formattedAddress: string,
-  chainId: ChainId,
+  chainId: ChainId | string,
 ) {
 
   if (formattedAddress?.match(/0x/)) {

--- a/src/lib/hooks.ts
+++ b/src/lib/hooks.ts
@@ -59,83 +59,143 @@ export function useChainId() {
   }
 }
 
-const collections = {
+export function userFriendlyRouteToAddress(
+  formattedAddress: string,
+  chainId: ChainId,
+) {
+
+  if (formattedAddress?.match(/0x/)) {
+    return formattedAddress
+  }
+
+  if (!collections?.[chainId]) {
+    return formattedAddress
+  } else {
+
+    let tokenAddress = collections?.[chainId]?.find(t => formattedAddress === t.route)
+    return !!tokenAddress?.address
+      ? tokenAddress.address
+      : formattedAddress
+  }
+}
+
+export interface CollectionItem {
+  name: string
+  route?: string
+  address: string
+}
+
+export interface Collections {
+  [key: number]: CollectionItem[]
+}
+
+export const collections: Collections = {
   [ChainId.Rinkeby]: [
     {
       name: "Extra Life",
+      route: "extra-life",
       address: "0x5e6ae51147d1ec18edccae516a59fb0a26a0b48f",
     },
     {
       name: "Keys",
+      route: "keys",
       address: "0x25ee208b4f8636b5ceaafdee051bf0bfe514f5f6",
     },
-    { name: "Legions", address: "0x6fd12312f70fa5b04d66584600f39abe31a99708" },
+    {
+      name: "Legions",
+      route: "legions",
+      address: "0x6fd12312f70fa5b04d66584600f39abe31a99708"
+    },
     {
       name: "Legions Genesis",
+      route: "legions-genesis",
       address: "0xac2f8732a67c15bf81f8a6181364ce753e915037",
     },
-    // { name: "Life", address: "#" },
+    // {
+    //   name: "Life",
+    //   route: "life",
+    //   address: "#"
+    // },
     {
       name: "Seed of Life",
+      route: "seed-of-life",
       address: "0x6a67fbf40142e3db2e6a950a4d48b0eb41107ce8",
     },
     {
       name: "Smol Bodies",
+      route: "smol-bodies",
       address: "0x9e638bfe78b372b8f5cc63cf6b01b90f568496cb",
     },
     {
       name: "Smol Brains",
+      route: "smol-brains",
       address: "0x4feea06250d9f315a6a454c9c8a7fcbcf8701210",
     },
     {
       name: "Smol Brains Land",
+      route: "smol-brains-land",
       address: "0xe42c57ab8e093d21e52cb07b5f32b1b106cdbfe4",
     },
     {
       name: "Treasures",
+      route: "treasures",
       address: "0x61b468f85b2e50baa0b1729ffc99efe9ef0428f0",
     },
     {
       name: "Smol Cars",
+      route: "smol-cars",
       address: "0x16bdf0b2d8bb8e98aecb32e004febf9653da5f43",
     },
   ],
   [ChainId.Arbitrum]: [
     {
       name: "Extra Life",
+      route: "extra-life",
       address: "0x21e1969884d477afd2afd4ad668864a0eebd644c",
     },
     {
       name: "Keys",
+      route: "keys",
       address: "0xf0a35ba261ece4fc12870e5b7b9e7790202ef9b5",
     },
-    { name: "Legions", address: "0x658365026d06f00965b5bb570727100e821e6508" },
+    {
+      name: "Legions",
+      route: "legions",
+      address: "0x658365026d06f00965b5bb570727100e821e6508"
+    },
     {
       name: "Legions Genesis",
+      route: "legions-genesis",
       address: "0xe83c0200e93cb1496054e387bddae590c07f0194",
     },
     {
       name: "Smol Bodies",
+      route: "smol-bodies",
       address: "0x17dacad7975960833f374622fad08b90ed67d1b5",
     },
     {
       name: "Smol Brains",
+      route: "smol-brains",
       address: "0x6325439389e0797ab35752b4f43a14c004f22a9c",
     },
     {
       name: "Smol Brains Land",
+      route: "smol-brains-land",
       address: "0xd666d1cc3102cd03e07794a61e5f4333b4239f53",
     },
     {
       name: "Smol Cars",
+      route: "smol-cars",
       address: "0xb16966dad2b5a5282b99846b23dcdf8c47b6132c",
     },
     {
       name: "Treasures",
+      route: "treasures",
       address: "0xebba467ecb6b21239178033189ceae27ca12eadf",
     },
     {
       name: "Seed of Life",
+      route: "seed-of-life",
       address: "0x3956c81a51feaed98d7a678d53f44b9166c8ed66",
     },
   ],
@@ -174,6 +234,7 @@ export function useTransferNFT(contract: string, standard: TokenStandard) {
 
   return transfer;
 }
+
 
 export function useApproveContract(contract: string, standard: TokenStandard) {
   const chainId = useChainId();

--- a/src/pages/collection/[address]/[tokenId].tsx
+++ b/src/pages/collection/[address]/[tokenId].tsx
@@ -29,6 +29,7 @@ import {
   useBuyItem,
   useChainId,
   useTransferNFT,
+  userFriendlyRouteToAddress,
 } from "../../../lib/hooks";
 import { CenterLoadingDots } from "../../../components/CenterLoadingDots";
 import {
@@ -97,10 +98,11 @@ export default function Example() {
   const { magicPrice } = useMagic();
 
   const formattedTokenId = Array.isArray(tokenId) ? tokenId[0] : tokenId;
+  const chainId = useChainId();
 
   const formattedAddress = Array.isArray(address)
-    ? address[0]
-    : address?.toLowerCase() ?? AddressZero;
+    ? userFriendlyRouteToAddress(address[0], chainId)
+    : userFriendlyRouteToAddress(address?.toLowerCase() ?? AddressZero, chainId);
 
   const { data, isLoading, isIdle } = useQuery(
     "details",
@@ -110,7 +112,7 @@ export default function Example() {
         tokenId: formattedTokenId,
       }),
     {
-      enabled: !!address || !!tokenId,
+      enabled: !!formattedAddress || !!tokenId,
       refetchInterval: false,
     }
   );
@@ -145,7 +147,7 @@ export default function Example() {
       }),
     {
       enabled:
-        !!address &&
+        !!formattedAddress &&
         !!tokenId &&
         data?.collection?.standard === TokenStandard.Erc1155,
       getNextPageParam: (_, pages) => pages.length * MAX_ITEMS_PER_PAGE,
@@ -189,7 +191,6 @@ export default function Example() {
 
   const { send, state } = useBuyItem();
 
-  const chainId = useChainId();
 
   React.useEffect(() => {
     if (state.status === "Success") {

--- a/src/pages/collection/[address]/index.tsx
+++ b/src/pages/collection/[address]/index.tsx
@@ -37,6 +37,7 @@ import { SearchAutocomplete } from "../../../components/SearchAutocomplete";
 import { Item } from "react-stately";
 import Listings from "../../../components/Listings";
 import Button from "../../../components/Button";
+import { userFriendlyRouteToAddress, useChainId, } from "../../../lib/hooks";
 
 const MAX_ITEMS_PER_PAGE = 42;
 
@@ -164,7 +165,7 @@ const getInititalFilters = (search: string | undefined) => {
     {}
   );
 };
-/* 
+/*
 
 */
 
@@ -239,12 +240,13 @@ const Collection = () => {
   const [mobileFiltersOpen, setMobileFiltersOpen] = useState(false);
 
   const filters = getInititalFilters(formattedSearch);
+  const chainId = useChainId()
 
   const sortParam = sort ?? OrderDirection.Asc;
   const activitySortParam = activitySort ?? "time";
   const formattedAddress = Array.isArray(address)
-    ? address[0]
-    : address?.toLowerCase() ?? AddressZero;
+    ? userFriendlyRouteToAddress(address[0], chainId)
+    : userFriendlyRouteToAddress(address ?? AddressZero, chainId);
 
   const formattedTab = tab ? (Array.isArray(tab) ? tab[0] : tab) : "collection";
 
@@ -264,13 +266,13 @@ const Collection = () => {
   );
 
   const { data: collectionData } = useQuery(
-    ["collection", address],
+    ["collection", formattedAddress],
     () =>
       client.getCollectionInfo({
         id: formattedAddress,
       }),
     {
-      enabled: !!address,
+      enabled: !!formattedAddress,
       refetchInterval: false,
     }
   );
@@ -280,13 +282,13 @@ const Collection = () => {
   );
 
   const { data: statData } = useQuery(
-    ["stats", address],
+    ["stats", formattedAddress],
     () =>
       client.getCollectionStats({
         id: formattedAddress,
       }),
     {
-      enabled: !!address,
+      enabled: !!formattedAddress,
     }
   );
 
@@ -326,7 +328,7 @@ const Collection = () => {
           : OrderDirection.Asc,
       }),
     {
-      enabled: !!address && !!collectionData,
+      enabled: !!formattedAddress && !!collectionData,
       getNextPageParam: (_, pages) => pages.length * MAX_ITEMS_PER_PAGE,
     }
   );
@@ -334,7 +336,7 @@ const Collection = () => {
   // reset searchParams on address change
   useEffect(() => {
     setSearchParams("");
-  }, [address]);
+  }, [formattedAddress]);
 
   const collection =
     listingData?.pages[listingData.pages.length - 1]?.collection;

--- a/src/pages/collection/[address]/index.tsx
+++ b/src/pages/collection/[address]/index.tsx
@@ -246,7 +246,7 @@ const Collection = () => {
   const activitySortParam = activitySort ?? "time";
   const formattedAddress = Array.isArray(address)
     ? userFriendlyRouteToAddress(address[0], chainId)
-    : userFriendlyRouteToAddress(address ?? AddressZero, chainId);
+    : userFriendlyRouteToAddress(address?.toLowerCase() ?? AddressZero, chainId);
 
   const formattedTab = tab ? (Array.isArray(tab) ? tab[0] : tab) : "collection";
 


### PR DESCRIPTION
Added a small UX update to let you access collections using dash-case names (optional), e.g. `/collections/smol-brains` or `collections/legions`

![image](https://user-images.githubusercontent.com/4037878/147380407-5ca318c8-868d-4d50-b2a0-2a91509ebb9f.png)
