### PR TITLE
Add USD value to collection Activity table

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,4 +1,4 @@
-NEXT_PUBLIC_GRAPHQL_URL=https://api.thegraph.com/subgraphs/name/wyze/treasure-marketplace
+NEXT_PUBLIC_GRAPHQL_URL=https://api.thegraph.com/subgraphs/name/wyze/treasure-marketplace-dev
 NEXT_PUBLIC_VERCEL_ENV=dev
 NEXT_PUBLIC_ALCHEMY_KEY=koj2zAjEWZz5nhLYsdQEEls8UZCEpPRd
 

--- a/.env.development
+++ b/.env.development
@@ -1,4 +1,4 @@
-NEXT_PUBLIC_GRAPHQL_URL=https://api.thegraph.com/subgraphs/name/wyze/treasure-marketplace-dev
+NEXT_PUBLIC_GRAPHQL_URL=https://api.thegraph.com/subgraphs/name/wyze/treasure-marketplace
 NEXT_PUBLIC_VERCEL_ENV=dev
 NEXT_PUBLIC_ALCHEMY_KEY=koj2zAjEWZz5nhLYsdQEEls8UZCEpPRd
 

--- a/src/components/Listings.tsx
+++ b/src/components/Listings.tsx
@@ -9,10 +9,9 @@ import { Menu, Transition, Disclosure } from "@headlessui/react";
 import { formatDistanceToNow } from "date-fns";
 import {
   formatPrice,
-  generateIpfsLink,
+  formatNumberUsd,
   getCollectionSlugFromName,
   getCollectionNameFromAddress,
-  formatPriceUsd,
 } from "../utils";
 import { useChainId } from "../lib/hooks";
 import { shortenAddress } from "@yuyao17/corefork";
@@ -38,7 +37,7 @@ const Listings = ({
 }) => {
   const router = useRouter();
   const chainId = useChainId();
-  const { ethPrice, usdPrice } = useMagic();
+  const { usdPrice } = useMagic();
 
   return (
     <div className="flex-1 flex items-stretch overflow-hidden">
@@ -191,13 +190,10 @@ const Listings = ({
                       <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900 dark:text-gray-700">
                         <div className="flex items-center">
                           {formatPrice(listing.pricePerItem)}
-                          <div className="text-xs px-1 text-gray-800 dark:text-gray-700">
-                            MAGIC
-                          </div>
+                          <div className="text-xs px-1">MAGIC</div>
                         </div>
                         <div className="text-gray-500 text-xs">
-                          $
-                          {formatPriceUsd(
+                          {formatNumberUsd(
                             parseFloat(formatEther(listing.pricePerItem)) *
                               parseFloat(usdPrice)
                           )}

--- a/src/components/Listings.tsx
+++ b/src/components/Listings.tsx
@@ -5,13 +5,14 @@ import {
 } from "@heroicons/react/solid";
 import { Fragment } from "react";
 import { ListingFieldsFragment } from "../../generated/graphql";
-import { Menu, Transition } from "@headlessui/react";
+import { Menu, Transition, Disclosure } from "@headlessui/react";
 import { formatDistanceToNow } from "date-fns";
 import {
   formatPrice,
   generateIpfsLink,
   getCollectionSlugFromName,
   getCollectionNameFromAddress,
+  formatPriceUsd,
 } from "../utils";
 import { useChainId } from "../lib/hooks";
 import { shortenAddress } from "@yuyao17/corefork";
@@ -19,8 +20,9 @@ import { useRouter } from "next/router";
 import Image from "next/image";
 import QueryLink from "./QueryLink";
 import classNames from "clsx";
-import { Disclosure } from "@headlessui/react";
 import Link from "next/link";
+import { useMagic } from "../context/magicContext";
+import { formatEther } from "ethers/lib/utils";
 
 const sortOptions = [
   { name: "Highest Price", value: "price" },
@@ -36,6 +38,7 @@ const Listings = ({
 }) => {
   const router = useRouter();
   const chainId = useChainId();
+  const { ethPrice, usdPrice } = useMagic();
 
   return (
     <div className="flex-1 flex items-stretch overflow-hidden">
@@ -118,7 +121,7 @@ const Listings = ({
                     scope="col"
                     className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider"
                   >
-                    Price ($MAGIC)
+                    Price
                   </th>
                   <th
                     scope="col"
@@ -191,7 +194,19 @@ const Listings = ({
                         </div>
                       </td>
                       <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900 dark:text-gray-700">
-                        {formatPrice(listing.pricePerItem)}
+                        <div className="flex items-center">
+                          {formatPrice(listing.pricePerItem)}
+                          <div className="text-xs px-1 text-gray-800 dark:text-gray-700">
+                            MAGIC
+                          </div>
+                        </div>
+                        <div className="text-gray-500 text-xs">
+                          $
+                          {formatPriceUsd(
+                            parseFloat(formatEther(listing.pricePerItem)) *
+                              parseFloat(usdPrice)
+                          )}
+                        </div>
                       </td>
                       <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900 dark:text-gray-700">
                         {listing.quantity}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -23,8 +23,12 @@ export const generateIpfsLink = (hash: string) => {
 export const formatNumber = (number: number) =>
   new Intl.NumberFormat().format(number);
 
-export const formatPriceUsd = (number: number) =>
-  new Intl.NumberFormat("en", { minimumFractionDigits: 2 }).format(number);
+export const formatNumberUsd = (number: number) =>
+  new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    minimumFractionDigits: 2,
+  }).format(number);
 
 export const formatPrice = (price: BigNumberish) =>
   formatNumber(parseFloat(formatEther(price)));

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -29,6 +29,9 @@ export const generateIpfsLink = (hash: string) => {
 export const formatNumber = (number: number) =>
   new Intl.NumberFormat().format(number);
 
+export const formatPriceUsd = (number: number) =>
+  new Intl.NumberFormat("en", { minimumFractionDigits: 2 }).format(number);
+
 export const formatPrice = (price: BigNumberish) =>
   formatNumber(parseFloat(formatEther(price)));
 


### PR DESCRIPTION
## This PR Includes the following changes

- Remove the text `$MAGIC` from the Activity table header since the field contains both MAGIC/USD values
- Added calculation of current USD value of the activity txn price and display it below the MAGIC quantity (see screenshot below)
- Added a new `formatNumberUsd` util function to facilitate USD display

![image](https://user-images.githubusercontent.com/3385743/148150563-bc6a62cd-0252-4da0-b146-59b479cd0a42.png)

cc: @wyze @jcheese1 