### PR TITLE
Use MagicIcon instead of $MAGIC

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -29,6 +29,7 @@ import Image from "next/image";
 import { WalletConnectConnector } from "@web3-react/walletconnect-connector";
 import { useCollections } from "../lib/hooks";
 import { getCollectionSlugFromName } from "../utils";
+import { MagicIcon } from "./Icons";
 
 const walletconnect = new WalletConnectConnector({
   rpc: {
@@ -155,7 +156,7 @@ const Header = () => {
                       <span className="text-white block">
                         {formatNumber(parseFloat(formatEther(magicBalance)))}
                       </span>{" "}
-                      <span className="text-white block ml-2">$MAGIC</span>
+                      <MagicIcon className="h-[0.8rem] w-[0.8rem] text-white ml-2 sm:h-4 sm:w-4 self-end" />
                     </div>
                     <div className="flex items-center justify-center px-2 sm:px-3 py-2 rounded-lg dark:bg-gray-800 bg-red-600 text-white text-xs sm:text-sm">
                       {shortenAddress(account)}
@@ -255,10 +256,11 @@ const Header = () => {
 
                   <div className="flex-1 flex items-center justify-end">
                     <button
-                      className="text-gray-700 block px-4 py-2 text-sm dark:text-gray-200"
+                      className="text-gray-700 block px-4 py-2 text-sm dark:text-gray-200 border rounded border-red-500"
                       onClick={() => setSushiModalOpen(true)}
                     >
-                      Purchase $MAGIC
+                      Purchase
+                      <MagicIcon className="inline-flex text-red-500 ml-2 h-[1rem] w-[1rem]" />
                     </button>
                     <div className="flex items-center">
                       {account ? (
@@ -269,9 +271,7 @@ const Header = () => {
                                 parseFloat(formatEther(magicBalance))
                               )}
                             </span>{" "}
-                            <span className="text-white block ml-2">
-                              $MAGIC
-                            </span>
+                            <MagicIcon className="inline-flex text-white ml-2 h-[1rem] w-[1rem]" />
                           </div>
                           <div className="flex items-center px-2 sm:px-3 py-2 rounded-lg dark:bg-gray-800 bg-red-600 text-white text-xs sm:text-sm">
                             {shortenAddress(account)}
@@ -286,7 +286,7 @@ const Header = () => {
                         </button>
                       )}
 
-                      <div className="ml-4 flow-root sm:border-l border-gray-200 pl-4 sm:pl-6 text-sm">
+                      <div className="ml-4 flow-root sm:border-l border-gray-200 sm:pl-6 text-sm">
                         <Link href="/activity" passHref>
                           <a className="hover:text-gray-900 text-gray-500 dark:hover:text-gray-200">
                             Activity

--- a/src/components/Listings.tsx
+++ b/src/components/Listings.tsx
@@ -22,6 +22,7 @@ import { Disclosure } from "@headlessui/react";
 import Link from "next/link";
 import { useQuery } from "react-query";
 import { bridgeworld, client } from "../lib/client";
+import { MagicIcon } from "./Icons";
 
 const sortOptions = [
   { name: "Highest Price", value: "price" },
@@ -156,7 +157,7 @@ const Listings = ({
                     scope="col"
                     className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider"
                   >
-                    Price ($MAGIC)
+                    Price (<MagicIcon className="inline-flex h-[0.6rem] w-[0.6rem]" />)
                   </th>
                   <th
                     scope="col"
@@ -355,10 +356,10 @@ const Listings = ({
                                   {metadata?.name ?? ""}
                                 </span>
                                 <span>
+                                  <MagicIcon className="inline-flex h-[0.8rem] w-[0.8rem] text-red-500 mr-1 self-end" />
                                   <span className="text-gray-900 font-medium">
                                     {formatPrice(listing.pricePerItem)}
-                                  </span>{" "}
-                                  $MAGIC
+                                  </span>
                                 </span>
                               </span>
                             </span>

--- a/src/pages/collection/[address]/[tokenId].tsx
+++ b/src/pages/collection/[address]/[tokenId].tsx
@@ -57,7 +57,12 @@ import { Contracts } from "../../../const";
 import { targetNftT } from "../../../types";
 import { Tooltip } from "../../../components/Tooltip";
 import { utils } from "ethers";
-import { EthIcon, SwapIcon, UsdIcon } from "../../../components/Icons";
+import {
+  EthIcon,
+  MagicIcon,
+  SwapIcon,
+  UsdIcon,
+} from "../../../components/Icons";
 
 const MAX_ITEMS_PER_PAGE = 10;
 
@@ -544,10 +549,8 @@ export default function Example() {
                     <div className="mt-10">
                       <h2 className="sr-only">Price</h2>
                       <p className="text-3xl text-gray-900 dark:text-gray-300">
+                        <MagicIcon className="inline-flex text-red-500 h-[text-3xl] w-[text-3xl] sm:h-6 sm:w-6 self-end mr-2" />
                         {formatPrice(tokenInfo.lowestPrice[0].pricePerItem)}
-                        <span className="ml-2 text-xs dark:text-gray-400">
-                          $MAGIC
-                        </span>
                       </p>
                       <div className="text-gray-500 text-sm mt-2">
                         ≈{" "}
@@ -1110,9 +1113,9 @@ const timelineContent = (
           {listing.buyer?.id ? shortenIfAddress(listing.buyer.id) : "Unknown"}{" "}
           for{" "}
           <span className="font-medium text-gray-900 dark:text-gray-300">
+            <MagicIcon className="inline-flex h-[0.8rem] w-[0.8rem] mr-1 self-end" />
             {formatPrice(listing.pricePerItem)}
-          </span>{" "}
-          $MAGIC
+          </span>
         </p>
       );
     case Status.Active:
@@ -1120,9 +1123,9 @@ const timelineContent = (
         <p>
           {shortenIfAddress(listing.seller.id)} listed this item for{" "}
           <span className="font-medium text-gray-900 dark:text-gray-300">
+            <MagicIcon className="inline-flex h-[0.8rem] w-[0.8rem] mr-1 self-end" />
             {formatPrice(listing.pricePerItem)}
-          </span>{" "}
-          $MAGIC
+          </span>
         </p>
       );
     case Status.Inactive:
@@ -1361,9 +1364,10 @@ const PurchaseItemModal = ({
 
                 {payload.standard === TokenStandard.ERC1155 && (
                   <div className="flex-1 pt-4 flex items-end justify-between">
-                    <p className="mt-1 text-xs font-medium text-gray-900 dark:text-gray-100">
-                      {formatEther(payload.pricePerItem)} $MAGIC{" "}
-                      <span className="text-[0.5rem] text-gray-500 dark:text-gray-400">
+                    <p className="mt-1 text-xs self-center font-medium text-gray-900 dark:text-gray-100">
+                      <MagicIcon className="inline-flex h-[0.8rem] w-[0.8rem] text-red-500 mr-1 self-end" />
+                      {formatEther(payload.pricePerItem)}{" "}
+                      <span className="text-[0.6rem] text-gray-500 dark:text-gray-400">
                         Per Item
                       </span>
                     </p>
@@ -1397,7 +1401,10 @@ const PurchaseItemModal = ({
             <div className="flex items-center justify-between border-t border-gray-200 pt-6">
               <dt className="text-base font-medium">Total</dt>
               <dd className="text-base font-medium text-gray-900 dark:text-gray-100 flex flex-col items-end">
-                <p>{totalPrice} $MAGIC</p>
+                <p>
+                  <MagicIcon className="inline-flex h-[0.8rem] w-[0.8rem] text-red-500 sm:h-4 sm:w-4 mr-1 self-end" />
+                  {totalPrice}
+                </p>
                 <p className="text-gray-500 text-sm mt-1">
                   ≈ <CurrencySwitcher price={totalPrice} />
                 </p>
@@ -1414,7 +1421,9 @@ const PurchaseItemModal = ({
                 loadingText="Approving $MAGIC..."
                 variant="secondary"
               >
-                Approve $MAGIC to purchase this item
+                Approve
+                <MagicIcon className="inline-flex h-[0.8rem] w-[0.8rem] text-red-500 sm:h-4 sm:w-4 ml-1 mr-1 self-end" />
+                to purchase this item
               </Button>
             ) : (
               <>

--- a/src/pages/collection/[address]/index.tsx
+++ b/src/pages/collection/[address]/index.tsx
@@ -715,7 +715,7 @@ const Collection = () => {
               <div className="mt-12 overflow-hidden flex flex-col">
                 <dl className="sm:-mx-8 -mt-8 flex divide-x-2">
                   <div className="flex flex-col px-6 sm:px-8 pt-8">
-                    <dt className="order-2 text-[0.4rem] sm:text-base font-medium text-gray-500 dark:text-gray-400 mt-2 sm:mt-4 flex">
+                    <dt className="order-2 text-[0.6rem] sm:text-base font-medium text-gray-500 dark:text-gray-400 mt-2 sm:mt-4 flex">
                       <span className="capsize">Floor Price</span>
                       <button
                         className="inline-flex self-end items-center ml-2"
@@ -735,9 +735,9 @@ const Collection = () => {
                     </dt>
                     <dd className="order-1 text-base font-extrabold text-red-600 dark:text-gray-200 sm:text-3xl flex">
                       {floorCurrency === "eth" ? (
-                        <EthIcon className="h-[0.6rem] w-[0.6rem] sm:h-4 sm:w-4 self-end mr-2" />
+                        <EthIcon className="h-[0.8rem] w-[0.8rem] sm:h-5 sm:w-5 self-end mr-2" />
                       ) : (
-                        <MagicIcon className="h-[0.6rem] w-[0.6rem] sm:h-4 sm:w-4 self-end mr-2" />
+                        <MagicIcon className="h-[0.8rem] w-[0.8rem] sm:h-5 sm:w-5 self-end mr-2" />
                       )}
                       <span className="capsize">
                         {floorCurrency === "eth"
@@ -753,7 +753,7 @@ const Collection = () => {
                     </dd>
                   </div>
                   <div className="flex flex-col px-6 sm:px-8 pt-8">
-                    <dt className="order-2 text-[0.4rem] sm:text-base font-medium text-gray-500 dark:text-gray-400 mt-2 sm:mt-4">
+                    <dt className="order-2 text-[0.6rem] sm:text-base font-medium text-gray-500 dark:text-gray-400 mt-2 sm:mt-4">
                       Total Listings
                     </dt>
                     <dd className="order-1 text-base font-extrabold text-red-600 dark:text-gray-200 sm:text-3xl capsize">
@@ -761,8 +761,9 @@ const Collection = () => {
                     </dd>
                   </div>
                   <div className="flex flex-col px-6 sm:px-8 pt-8">
-                    <dt className="order-2 text-[0.4rem] sm:text-base font-medium text-gray-500 dark:text-gray-400 mt-2 sm:mt-4">
-                      Volume ($MAGIC)
+                    <dt className="order-2 text-[0.6rem] sm:text-base font-medium text-gray-500 dark:text-gray-400 mt-2 sm:mt-4">
+                      Volume
+                      <MagicIcon className="inline-flex h-[0.6rem] w-[0.6rem] sm:h-4 sm:w-4 self-end ml-1" />
                     </dt>
                     <dd className="order-1 text-base font-extrabold text-red-600 dark:text-gray-200 sm:text-3xl capsize">
                       {abbreviatePrice(statData.collection.totalVolume)}
@@ -1113,16 +1114,14 @@ const Collection = () => {
                                     {metadata?.name}
                                   </p>
                                   <p className="dark:text-gray-100 text-sm xl:text-base capsize">
+                                    <MagicIcon className="inline-flex h-[0.8rem] w-[0.8rem] text-red-500 self-end mr-1" />
                                     {formatNumber(
                                       parseFloat(
                                         formatEther(
                                           token?.listings?.[0]?.pricePerItem
                                         )
                                       )
-                                    )}{" "}
-                                    <span className="text-[0.5rem] xl:text-xs font-light">
-                                      $MAGIC
-                                    </span>
+                                    )}
                                   </p>
                                   <p className="text-xs text-[0.6rem] ml-auto whitespace-nowrap">
                                     <span className="text-gray-500 dark:text-gray-400">
@@ -1187,14 +1186,12 @@ const Collection = () => {
                                     {metadata?.name}
                                   </p>
                                   <p className="dark:text-gray-100 text-sm xl:text-base capsize">
+                                    <MagicIcon className="inline-flex h-[0.8rem] w-[0.8rem] text-red-500 self-start mr-1" />
                                     {formatNumber(
                                       parseFloat(
                                         formatEther(listing.pricePerItem)
                                       )
-                                    )}{" "}
-                                    <span className="text-[0.5rem] xl:text-xs font-light">
-                                      $MAGIC
-                                    </span>
+                                    )}
                                   </p>
                                 </div>
                               </li>
@@ -1294,7 +1291,9 @@ const DetailedFloorPriceModal = ({
                         scope="col"
                         className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider"
                       >
-                        Floor Price ($MAGIC)
+                        Floor Price (
+                        <MagicIcon className="h-[0.6rem] w-[0.6rem] sm:h-4 sm:w-4" />
+                        )
                       </th>
                     </tr>
                   </thead>

--- a/src/pages/inventory/[[...section]].tsx
+++ b/src/pages/inventory/[[...section]].tsx
@@ -42,6 +42,7 @@ import { formatEther } from "ethers/lib/utils";
 import { formatDistanceToNow } from "date-fns";
 import { FEE, USER_SHARE } from "../../const";
 import { TokenStandard } from "../../../generated/queries.graphql";
+import { MagicIcon } from "../../components/Icons";
 
 type DrawerProps = {
   actions: Array<"create" | "remove" | "update">;
@@ -262,15 +263,17 @@ const Drawer = ({
                                     className="text-gray-500 dark:text-gray-400 sm:text-sm"
                                     id="price-currency"
                                   >
-                                    $MAGIC
+                                    <MagicIcon className="inline-flex h-[0.8rem] w-[0.8rem] sm:h-4 sm:w-4 text-red-500 self-end mr-1" />
                                   </span>
                                 </div>
                               </div>
                               <p className="flex text-red-600 text-[0.75rem] mt-1 h-[1rem]">
-                                {priceBelowFloorWarning &&
-                                  `Price is below floor of ${
-                                    statData?.collection?.floorPrice / 10 ** 18
-                                  } $MAGIC`}
+                                  {priceBelowFloorWarning &&
+                                    <Fragment>
+                                      Price is below floor of
+                                      <MagicIcon className="inline-flex h-[0.6rem] w-[0.6rem] text-red-500 self-end ml-1 mr-1" />
+                                      {Math.floor(statData?.collection?.floorPrice / 10 ** 18)}
+                                    </Fragment>}
                               </p>
                             </div>
                             <div>
@@ -450,8 +453,9 @@ const Drawer = ({
                                 Royalties ({FEE * 100 + "%"})
                               </p>
                               <p>
-                                ≈ {formatNumber(parseFloat(price || "0") * FEE)}{" "}
-                                $MAGIC
+                                  ≈
+                                  <MagicIcon className="inline-flex h-[0.6rem] w-[0.6rem] text-red-500 self-end ml-1 mr-1" />
+                                  {formatNumber(parseFloat(price || "0") * FEE)}
                               </p>
                             </div>
                             <div className="flex justify-between px-2">
@@ -459,11 +463,11 @@ const Drawer = ({
                                 Your share ({USER_SHARE * 100 + "%"})
                               </p>
                               <p>
-                                ≈{" "}
+                                ≈
+                                <MagicIcon className="inline-flex h-[0.6rem] w-[0.6rem] text-red-500 self-end ml-1 mr-1" />
                                 {formatNumber(
                                   parseFloat(price || "0") * USER_SHARE
-                                )}{" "}
-                                $MAGIC
+                                )}
                               </p>
                             </div>
                           </div>
@@ -882,10 +886,10 @@ const Inventory = () => {
                           </Link>
                           {pricePerItem && (
                             <p className="dark:text-gray-100">
+                              <MagicIcon className="inline-flex h-[0.8rem] w-[0.8rem] text-red-500 self-end ml-1 mr-1" />
                               {formatNumber(
                                 parseFloat(formatEther(pricePerItem))
-                              )}{" "}
-                              <span className="text-xs font-light">$MAGIC</span>
+                              )}
                             </p>
                           )}
                           {!expires &&


### PR DESCRIPTION
**In this PR**
text $MAGIC is replaced with the `MagicIcon`, bringing more color to the pages, and looking better in my opinion.

![image](https://user-images.githubusercontent.com/62888804/150969733-1f1746d8-15ef-4066-95bd-5b06acd68209.png)

![image](https://user-images.githubusercontent.com/62888804/150969805-306d7fde-50a5-4633-b89f-c454655ef4ec.png)

@wyze @jcheese1
