### PR TITLE
Fix number formatting on collection total listings

### DIFF
--- a/src/pages/collection/[address]/index.tsx
+++ b/src/pages/collection/[address]/index.tsx
@@ -602,7 +602,7 @@ const Collection = () => {
                       Total Listings
                     </dt>
                     <dd className="order-1 text-base font-extrabold text-red-600 dark:text-gray-200 sm:text-3xl capsize">
-                      {statData.collection.totalListings}
+                      {formatNumber(statData.collection.totalListings)}
                     </dd>
                   </div>
                   <div className="flex flex-col px-6 sm:px-8 pt-8">


### PR DESCRIPTION
Fixes #141 

- Adds number formatting to "Total Listings" count on collection pages

@wyze  @jcheese1 