### PR TITLE
Fix full page going into loading state when new page is loading

### DIFF
--- a/src/pages/collection/[address]/index.tsx
+++ b/src/pages/collection/[address]/index.tsx
@@ -478,8 +478,6 @@ const Collection = () => {
     }
   );
 
-  console.log(metadataData);
-
   const { data: legionMetadataData } = useQuery(
     ["metadata-legions", listingData?.pages.length],
     () =>

--- a/src/pages/collection/[address]/index.tsx
+++ b/src/pages/collection/[address]/index.tsx
@@ -354,6 +354,9 @@ const Collection = () => {
   const isERC1155 =
     collectionData?.collection?.standard === TokenStandard.ERC1155;
 
+  const isLegions =
+    getCollectionNameFromAddress(formattedAddress, chainId) === "Legions";
+
   const searchFilters = React.useMemo(
     () => formatSearchFilter(formattedSearch),
     [formattedSearch]
@@ -383,10 +386,7 @@ const Collection = () => {
         name: searchParams,
       }),
     {
-      enabled:
-        !!formattedAddress &&
-        Boolean(searchParams) &&
-        getCollectionNameFromAddress(formattedAddress, chainId) !== "Legions",
+      enabled: !!formattedAddress && Boolean(searchParams) && !isLegions,
       refetchInterval: false,
     }
   );
@@ -400,10 +400,7 @@ const Collection = () => {
           name: searchParams,
         }),
       {
-        enabled:
-          !!formattedAddress &&
-          Boolean(searchParams) &&
-          getCollectionNameFromAddress(formattedAddress, chainId) === "Legions",
+        enabled: !!formattedAddress && Boolean(searchParams) && isLegions,
         refetchInterval: false,
       }
     );
@@ -461,7 +458,7 @@ const Collection = () => {
     }
   );
 
-  const { data: metadataData, isLoading: isMetadataLoading } = useQuery(
+  const { data: metadataData } = useQuery(
     ["metadata", formattedAddress, listingData, filteredTokenIds],
     () =>
       client.getCollectionMetadata({
@@ -476,12 +473,12 @@ const Collection = () => {
         }, []),
       }),
     {
-      enabled:
-        !!formattedAddress &&
-        !!listingData &&
-        getCollectionNameFromAddress(formattedAddress, chainId) !== "Legions",
+      enabled: !!formattedAddress && !!listingData && !isLegions,
+      keepPreviousData: true,
     }
   );
+
+  console.log(metadataData);
 
   const { data: legionMetadataData } = useQuery(
     ["metadata-legions", listingData?.pages.length],
@@ -496,10 +493,8 @@ const Collection = () => {
           }, []) || [],
       }),
     {
-      enabled:
-        !!formattedAddress &&
-        !!listingData &&
-        getCollectionNameFromAddress(formattedAddress, chainId) === "Legions",
+      enabled: !!formattedAddress && !!listingData && isLegions,
+      keepPreviousData: true,
     }
   );
 
@@ -1089,7 +1084,7 @@ const Collection = () => {
                         {group.tokens
                           ?.filter((token) => Boolean(token?.listings?.length))
                           .map((token) => {
-                            const metadata = metadataData?.erc1155.find(
+                            const metadata = metadataData?.erc1155?.find(
                               (metadata) => metadata.tokenId === token.tokenId
                             );
 
@@ -1150,12 +1145,11 @@ const Collection = () => {
                               legionMetadataData?.tokens.find(
                                 (item) => item.id === listing.token.id
                               );
-                            const metadata =
-                              metadataData?.erc721?.find(
-                                (item) =>
-                                  item?.tokenId === listing.token.tokenId
-                              ) ??
-                              (legionsMetadata
+                            const erc721Metadata = metadataData?.erc721?.find(
+                              (item) => item?.tokenId === listing.token.tokenId
+                            );
+                            const metadata = isLegions
+                              ? legionsMetadata
                                 ? {
                                     id: legionsMetadata.id,
                                     name: legionsMetadata.name,
@@ -1166,7 +1160,8 @@ const Collection = () => {
                                       description: "Legions",
                                     },
                                   }
-                                : undefined);
+                                : erc721Metadata
+                              : erc721Metadata;
 
                             return (
                               <li key={listing.id} className="group">


### PR DESCRIPTION
Fixes #147 

Fixes issue with full page going into a loading state when paginating by preserving the metadata results from the previous page while the next is loading

New behavior, compare to demo in #147:

![loading_new](https://user-images.githubusercontent.com/1013230/152434435-d8c6b991-6e5e-4940-86f5-9e4d56721c1d.gif)

@wyze @jcheese1 