### PR TITLE
Remove whitespace as clickable part of `Link`

### DIFF
--- a/src/pages/collection/[address]/[tokenId].tsx
+++ b/src/pages/collection/[address]/[tokenId].tsx
@@ -516,7 +516,7 @@ export default function Example() {
 
                 <Link href={`/collection/${slugOrAddress}`}>
                   <a>
-                    <h2 className="text-red-500 dark:text-gray-500 tracking-wide uppercase">
+                    <h2 className="inline-block text-red-500 dark:text-gray-500 tracking-wide uppercase">
                       {data.collection.name}
                     </h2>
                   </a>


### PR DESCRIPTION
**Issue**
You were able to click the whole width of the collection title, not just the text itself.

@wyze @jcheese1 