### PR TITLE
Add attributes for treasure and consumables to item detail page

### DIFF
--- a/src/graphql/bridgeworld.graphql.ts
+++ b/src/graphql/bridgeworld.graphql.ts
@@ -25,6 +25,12 @@ export const getBridgeworldMetadata = gql`
           type
           size
         }
+        ... on TreasureInfo {
+          id
+          boost
+          category
+          tier
+        }
       }
     }
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,17 @@
 import {
+  ConsumableInfo,
+  LegionInfo,
+  Token,
+  TreasureInfo,
+} from "../generated/bridgeworld.graphql";
+import {
   ListingFieldsWithTokenFragment,
   TokenStandard,
 } from "../generated/marketplace.graphql";
+
+export type BridgeworldToken = Token & {
+  metadata: ConsumableInfo | LegionInfo | TreasureInfo;
+};
 
 export type NormalizedMetadata = Partial<{
   attributes: Array<{

--- a/src/utils/metadata.ts
+++ b/src/utils/metadata.ts
@@ -1,0 +1,113 @@
+import { formatDistanceToNow } from "date-fns";
+
+import { BridgeworldToken, NormalizedMetadata } from "../types";
+import { formatNumber, formatPercent } from "../utils";
+
+export function normalizeBridgeworldTokenMetadata(
+  token: BridgeworldToken
+): NormalizedMetadata {
+  const metadata = token.metadata;
+  const tokenMetadata: NormalizedMetadata = {
+    id: token.id,
+    description: "",
+    image: token.image,
+    name: token.name,
+    attributes: [],
+  };
+
+  if (metadata?.__typename === "ConsumableInfo") {
+    tokenMetadata.description = "Consumables";
+    tokenMetadata.attributes = [
+      {
+        attribute: {
+          name: "Size",
+          value: metadata.size?.toString() ?? "None",
+        },
+      },
+      {
+        attribute: {
+          name: "Type",
+          value: metadata.type,
+        },
+      },
+    ];
+  } else if (metadata?.__typename === "LegionInfo") {
+    tokenMetadata.description = "Legions";
+    tokenMetadata.attributes = [
+      {
+        attribute: {
+          name: "Atlas Mine Boost",
+          value: formatPercent(metadata.boost),
+        },
+      },
+      {
+        attribute: {
+          name: "Summon Fatigue",
+          value: metadata.cooldown
+            ? formatDistanceToNow(Number(metadata.cooldown.toString()))
+            : "None",
+        },
+      },
+      {
+        attribute: {
+          name: "Crafting Level",
+          value: metadata.crafting,
+        },
+      },
+      {
+        attribute: {
+          name: "Questing Level",
+          value: metadata.questing,
+        },
+      },
+      {
+        attribute: {
+          name: "Rarity",
+          value: metadata.rarity,
+        },
+      },
+      {
+        attribute: {
+          name: "Class",
+          value: metadata.role,
+        },
+      },
+      {
+        attribute: {
+          name: "Type",
+          value: metadata.type,
+        },
+      },
+      {
+        attribute: {
+          name: "Times Summoned",
+          value: formatNumber(Number(metadata.summons.toString())),
+        },
+      },
+    ];
+  } else if (metadata?.__typename === "TreasureInfo") {
+    tokenMetadata.description = "Treasures";
+    tokenMetadata.attributes = [
+      {
+        attribute: {
+          name: "Atlas Mine Boost",
+          value: formatPercent(metadata.boost),
+        },
+      },
+      {
+        attribute: {
+          name: "Category",
+          value: metadata.category,
+        },
+      },
+      {
+        attribute: {
+          name: "Tier",
+          value: metadata.tier,
+        },
+      },
+    ];
+  }
+
+  return tokenMetadata;
+}


### PR DESCRIPTION
Closes #169 

- Adds attributes metadata for Treasure and Consumables to the item detail page

<img width="603" alt="Screen Shot 2022-02-12 at 6 40 45 PM" src="https://user-images.githubusercontent.com/1013230/153738896-7fc89e74-82c1-4bbf-869e-4d16ccd28fa7.png">

<img width="602" alt="Screen Shot 2022-02-12 at 8 38 25 PM" src="https://user-images.githubusercontent.com/1013230/153738900-520207c3-e73a-4b64-887a-4efe070facb4.png">

