### PR TITLE
Fix overlapping text in legions listings for smaller screen sizes

### DIFF
--- a/src/pages/collection/[address]/index.tsx
+++ b/src/pages/collection/[address]/index.tsx
@@ -1315,7 +1315,9 @@ const Collection = () => {
                   </h2>
                   <ul
                     role="list"
-                    className="grid grid-cols-2 gap-y-10 sm:grid-cols-4 gap-x-6 lg:grid-cols-6 xl:gap-x-8"
+                    className={`grid grid-cols-2 gap-y-10 sm:grid-cols-4 gap-x-6 lg:grid-cols-4 xl:grid-cols-${
+                      attributeFilterList ? "4" : "6"
+                    } xl:gap-x-8`}
                   >
                     {listings.data?.pages.map((group, i) => (
                       <React.Fragment key={i}>
@@ -1508,7 +1510,7 @@ const Collection = () => {
                                     {role ? ` - ${role}` : ""}
                                   </p>
                                   {normalizedLegion ? (
-                                    <div>
+                                    <div className="flex">
                                       <Popover.Root>
                                         <Popover.Trigger asChild>
                                           <button>


### PR DESCRIPTION
Fixes #178 

- Changes to collection listings grid columns:
  - 4 cols for "lg" breakpoint
  - 4 cols for "xl" breakpoint when filter list is available
  - 6 cols for "xl" breakpoint when no filter list is available
- Fixes vertical alignment on (i) button

![Screen Shot 2022-02-14 at 12 45 57](https://user-images.githubusercontent.com/1013230/153944825-82d498cd-c4f1-4b22-b0e7-54343b3a9f14.png)
