### PR TITLE
Update Royalties and Share based on Quantity sold

### DIFF
--- a/src/pages/inventory/[[...section]].tsx
+++ b/src/pages/inventory/[[...section]].tsx
@@ -523,7 +523,10 @@ const Drawer = ({
                                 Royalties ({FEE * 100 + "%"})
                               </p>
                               <p>
-                                ≈ {formatNumber(parseFloat(price || "0") * FEE)}{" "}
+                                ≈{" "}
+                                {formatNumber(
+                                  parseFloat(price || "0") * FEE * +quantity
+                                )}{" "}
                                 $MAGIC
                               </p>
                             </div>
@@ -535,7 +538,9 @@ const Drawer = ({
                                 <p>
                                   ≈{" "}
                                   {formatNumber(
-                                    parseFloat(price || "0") * USER_SHARE
+                                    parseFloat(price || "0") *
+                                      USER_SHARE *
+                                      +quantity
                                   )}{" "}
                                   $MAGIC
                                 </p>


### PR DESCRIPTION
**Issue**
Selling multiple items at once does not update the `fees` and `share` based on quantity sold but on a single one.

This PR fixes this

![image](https://user-images.githubusercontent.com/62888804/154679273-a6abd989-0bd6-48bd-9978-1d19549cfe2a.png)

@wyze @jcheese1 