### PR TITLE
Keep Treasure Logo color consistent with light and dark mode

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -336,7 +336,7 @@ const Header = () => {
                   </div>
                   <div className="hidden lg:flex items-center mr-4">
                     <Link href="/" passHref>
-                      <a className="hover:text-gray-900 text-gray-500 dark:hover:text-red-500">
+                      <a className="text-red-500">
                         <span className="sr-only">Home</span>
                         <TreasureIcon />
                       </a>


### PR DESCRIPTION
Logo is not red when hovering in light mode.

Verified fix

https://user-images.githubusercontent.com/30575095/159136730-44c47aed-7dda-4cae-bf28-123fc0379642.mov


Fixes #207