### PR TITLE
Fix long load time and offset images in homepage collections

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -15,7 +15,8 @@ const collections = [
   {
     href: "legion-genesis",
     name: "Legion Genesis",
-    image: "/img/Warlock.png",
+    image:
+      "https://ipfs.io/ipfs/QmRqosGZZ6icx6uSDjLuFFMJiWDefZAiAZdpJdBK9BP5S4/Warlock.png",
     description: "The Origin Legions of Bridgeworld with a fixed supply.",
   },
   {
@@ -76,7 +77,8 @@ const collections = [
   {
     href: "treasures",
     name: "Treasures",
-    image: "/img/Honeycomb.gif",
+    image:
+      "https://ipfs.io/ipfs/Qmbyy8EWMzrSTSGG1bDNsYZfvnkcjAFNM5TXJqvsbuY8Dz/Honeycomb.gif",
     description:
       "Treasures are composable building blocks in Bridgeworld that will be used inter- and intra-metaverse.",
   },
@@ -127,8 +129,13 @@ export default function Home() {
                 className="group relative bg-white dark:bg-gray-500 border border-gray-200 dark:border-gray-600 rounded-lg flex flex-col overflow-hidden"
               >
                 <div className="relative aspect-w-3 aspect-h-3 bg-gray-200 group-hover:opacity-75 sm:aspect-none">
-                  {/* eslint-disable-next-line @next/next/no-img-element */}
-                  <img src={product.image} alt={product.name} />
+                  <Image
+                    src={product.image}
+                    alt={product.name}
+                    layout="responsive"
+                    width={400}
+                    height={400}
+                  />
                 </div>
                 <div className="flex-1 p-4 space-y-2 flex flex-col">
                   <h3 className="text-sm font-medium text-gray-900 dark:text-gray-50">


### PR DESCRIPTION
- Moves homepage collection thumbnails to use Next.js `Image` component to fix longer load times (particularly with the Legion Genesis/Warlock image)
- Fixes thumbnail image offset

**Before**

<img width="1259" alt="Screen Shot 2022-03-27 at 12 22 31 AM" src="https://user-images.githubusercontent.com/1013230/160266582-a9d90722-1e9a-4f1d-a94f-81e1d2e723e1.png">

**After**

<img width="1261" alt="Screen Shot 2022-03-27 at 12 25 01 AM" src="https://user-images.githubusercontent.com/1013230/160266599-5692e600-80bc-46cd-870d-6d16e198bb1b.png">