### PR TITLE
Purge all urls in cache on deploy

### DIFF
--- a/.github/workflows/post-deploy.yaml
+++ b/.github/workflows/post-deploy.yaml
@@ -10,4 +10,3 @@ jobs:
         env:
           CLOUDFLARE_ZONE: ${{ secrets.CLOUDFLARE_ZONE }}
           CLOUDFLARE_TOKEN: ${{ secrets.CLOUDFLARE_TOKEN }}
-          PURGE_URLS: '["https://marketplace.treasure.lol"]'


### PR DESCRIPTION
Marketplace repo has too many paths to list in the purge field, and wildcards are not supported with our Cloudflare plan. Full cache will need to be cleared on each deploy to avoid states where certain deep link pages (e.g. https://marketplace.treasure.lol/collection/treasures) are still referencing old versions of the JS code.