### PR TITLE
update alchemy provider config

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,6 +1,8 @@
 NEXT_PUBLIC_GRAPHQL_URL=https://api.thegraph.com/subgraphs/name/wyze/treasure-marketplace-dev
 NEXT_PUBLIC_VERCEL_ENV=dev
-NEXT_PUBLIC_ALCHEMY_KEY=koj2zAjEWZz5nhLYsdQEEls8UZCEpPRd
+NEXT_PUBLIC_ALCHEMY_KEY=
+NEXT_PUBLIC_ALCHEMY_KEY_DEV=
+NEXT_PUBLIC_ENABLE_TESTNET=true
 NEXT_PUBLIC_MARKETPLACE_SUBGRAPH=https://api.thegraph.com/subgraphs/name/treasureproject/marketplace-dev
 NEXT_PUBLIC_BRIDGEWORLD_SUBGRAPH=https://api.thegraph.com/subgraphs/name/treasureproject/bridgeworld-dev
 NEXT_PUBLIC_METADATA_SUBGRAPH=https://api.thegraph.com/subgraphs/name/treasureproject/metadata-dev

--- a/.env.production
+++ b/.env.production
@@ -1,6 +1,6 @@
 NEXT_PUBLIC_GRAPHQL_URL=https://api.thegraph.com/subgraphs/name/wyze/treasure-marketplace
 NEXT_PUBLIC_VERCEL_ENV=dev
-NEXT_PUBLIC_ALCHEMY_KEY=koj2zAjEWZz5nhLYsdQEEls8UZCEpPRd
+NEXT_PUBLIC_ALCHEMY_KEY=
 NEXT_PUBLIC_MARKETPLACE_SUBGRAPH=https://api.thegraph.com/subgraphs/name/treasureproject/marketplace
 NEXT_PUBLIC_BRIDGEWORLD_SUBGRAPH=https://api.thegraph.com/subgraphs/name/treasureproject/bridgeworld
 NEXT_PUBLIC_METADATA_SUBGRAPH=https://api.thegraph.com/subgraphs/name/treasureproject/metadata


### PR DESCRIPTION
- Users ethers' built-in `AlchemyProvider` class for define providers
- Removes old Alchemy keys from repo
- Updates config to only allow testnet in dev builds, saving calls to Rinkeby provider in production