### PR TITLE
Add KOTE Items collections

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -5,6 +5,7 @@ module.exports = {
       "storage.googleapis.com",
       "treasure-marketplace.mypinata.cloud",
       "cdn.talesofelleria.com",
+      "knightsoftheether.com",
     ],
   },
   async redirects() {

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -37,7 +37,9 @@ import { InboxIcon } from "@heroicons/react/solid";
 import { TreasureIcon } from "./Icons";
 
 const NEW_COLLECTIONS = [
-  "KOTE Squires",
+  "KOTE Rings",
+  "KOTE Potions",
+  "KOTE Trinkets",
   "SamuRise Items",
   "Smithonia Resources",
   "Swolercycles",

--- a/src/const.ts
+++ b/src/const.ts
@@ -289,7 +289,7 @@ const KOTE_POTIONS = {
   href: "kote-potions",
   name: "KOTE Potions",
   image:
-    "https://ipfs.io/ipfs/QmYZXbjHrKSoy5ZPutJPnnuZURr6NLbVpd323HZ3G3sX9D/strengthG.png",
+    "https://knightsoftheether.com/squires/images/potions/Phantom%20Phial.png",
   description:
     "1 of 3 item types in the Knights of the Ether ecosystem, Potions have 5 rarity tiers and 2 upgrade levels.",
   ...KOTE_DATA,
@@ -300,7 +300,7 @@ const KOTE_TRINKETS = {
   href: "kote-trinkets",
   name: "KOTE Trinkets",
   image:
-    "https://ipfs.io/ipfs/QmYZXbjHrKSoy5ZPutJPnnuZURr6NLbVpd323HZ3G3sX9D/strengthG.png",
+    "https://knightsoftheether.com/squires/images/trinkets/Golem%20Eye.png",
   description:
     "1 of 3 item types in the Knights of the Ether ecosystem, Trinkets have 5 rarity tiers.",
   ...KOTE_DATA,
@@ -311,7 +311,7 @@ const KOTE_RINGS = {
   href: "kote-rings",
   name: "KOTE Rings",
   image:
-    "https://ipfs.io/ipfs/QmYZXbjHrKSoy5ZPutJPnnuZURr6NLbVpd323HZ3G3sX9D/strengthG.png",
+    "https://knightsoftheether.com/squires/images/rings/Etheric%20Ring%20of%20Renewal.png",
   description:
     "1 of 3 item types in the Knights of the Ether ecosystem, Rings have 5 rarity tiers, 5 makes and 5 upgrade levels.",
   ...KOTE_DATA,

--- a/src/const.ts
+++ b/src/const.ts
@@ -57,6 +57,9 @@ export const smolverseItems = [
 
 export const METADATA_COLLECTIONS = [
   "KOTE Squires",
+  "KOTE Potions",
+  "KOTE Trinkets",
+  "KOTE Rings",
   "Peek-A-Boo",
   "SamuRise Items",
   "SamuRise Land",
@@ -81,6 +84,14 @@ const BATTLEFLY_DATA = {
   discord: "YzpajBfRNX ",
   twitter: "BattleFlyGame",
   website: "https://battlefly.game",
+} as const;
+
+const KOTE_DATA = {
+  cartridge: "ecosystem",
+  discord: "kote",
+  game: "https://knightsoftheether.com/squires",
+  twitter: "KnightsOfTheEth",
+  website: "https://knightsoftheether.com",
 } as const;
 
 const SMITHONIA_DATA = {
@@ -270,11 +281,41 @@ const KOTE_SQUIRES = {
     "https://ipfs.io/ipfs/QmYZXbjHrKSoy5ZPutJPnnuZURr6NLbVpd323HZ3G3sX9D/strengthG.png",
   description:
     "The support characters for Knights of the Ether, these 3,999 Squires quest on Arbitrum in search of $FIEF, potions, trinkets and rings. Each Squire comes in 1 of 4 classes, Strength, Wisdom, Luck or Faith. (You must own at least 1 Knight on L1 to send Squires out on Quests)",
-  cartridge: "ecosystem",
-  discord: "kote",
-  game: "https://knightsoftheether.com/squires",
-  twitter: "KnightsOfTheEth",
-  website: "https://knightsoftheether.com",
+  ...KOTE_DATA,
+  related: ["kote-potions", "kote-trinkets", "kote-rings"],
+} as const;
+
+const KOTE_POTIONS = {
+  href: "kote-potions",
+  name: "KOTE Potions",
+  image:
+    "https://ipfs.io/ipfs/QmYZXbjHrKSoy5ZPutJPnnuZURr6NLbVpd323HZ3G3sX9D/strengthG.png",
+  description:
+    "1 of 3 item types in the Knights of the Ether ecosystem, Potions have 5 rarity tiers and 2 upgrade levels.",
+  ...KOTE_DATA,
+  related: ["kote-squires", "kote-trinkets", "kote-rings"],
+} as const;
+
+const KOTE_TRINKETS = {
+  href: "kote-trinkets",
+  name: "KOTE Trinkets",
+  image:
+    "https://ipfs.io/ipfs/QmYZXbjHrKSoy5ZPutJPnnuZURr6NLbVpd323HZ3G3sX9D/strengthG.png",
+  description:
+    "1 of 3 item types in the Knights of the Ether ecosystem, Trinkets have 5 rarity tiers.",
+  ...KOTE_DATA,
+  related: ["kote-squires", "kote-potions", "kote-rings"],
+} as const;
+
+const KOTE_RINGS = {
+  href: "kote-rings",
+  name: "KOTE Rings",
+  image:
+    "https://ipfs.io/ipfs/QmYZXbjHrKSoy5ZPutJPnnuZURr6NLbVpd323HZ3G3sX9D/strengthG.png",
+  description:
+    "1 of 3 item types in the Knights of the Ether ecosystem, Rings have 5 rarity tiers, 5 makes and 5 upgrade levels.",
+  ...KOTE_DATA,
+  related: ["kote-squires", "kote-potions", "kote-trinkets"],
 } as const;
 
 const SWOLERCYCLES = {
@@ -504,6 +545,9 @@ export const ALL_COLLECTION_METADATA = [
   BATTLEFLY_FOUNDERS_V1,
   BATTLEFLY_FOUNDERS_V2,
   KOTE_SQUIRES,
+  KOTE_POTIONS,
+  KOTE_RINGS,
+  KOTE_TRINKETS,
   SAMURISE_LAND,
   SAMURISE_ITEMS,
   ...COLLECTION_METADATA,
@@ -567,7 +611,10 @@ export const COLLECTION_DESCRIPTIONS = {
       "SamuRise Land",
       "Smithonia Resources",
       "Smithonia Weapons",
-      "KOTE Squires",
+      "KOTE Squares",
+      "KOTE Rings",
+      "KOTE Potions",
+      "KOTE Trinkets",
       "Swolercycles",
       "The Lost Donkeys",
     ].includes(item.name)

--- a/src/const.ts
+++ b/src/const.ts
@@ -611,7 +611,7 @@ export const COLLECTION_DESCRIPTIONS = {
       "SamuRise Land",
       "Smithonia Resources",
       "Smithonia Weapons",
-      "KOTE Squares",
+      "KOTE Squires",
       "KOTE Rings",
       "KOTE Potions",
       "KOTE Trinkets",

--- a/src/pages/collection/[address]/[tokenId].tsx
+++ b/src/pages/collection/[address]/[tokenId].tsx
@@ -440,7 +440,7 @@ export default function TokenDetails({ og }: { og: MetadataProps }) {
                                     }}
                                     passHref
                                   >
-                                    <a className="border-2 border-red-400 dark:border-gray-400 rounded-md bg-red-200 dark:bg-gray-300 flex items-center flex-col py-2 hover:shadow-xl shadow-red-500/50">
+                                    <a className="border-2 border-red-400 dark:border-gray-400 rounded-md bg-red-200 dark:bg-gray-300 flex items-center flex-col py-2 hover:shadow-xl shadow-red-500/50 text-center">
                                       <p className="text-red-700 dark:text-gray-500 text-xs font-light">
                                         {attribute.name}
                                       </p>


### PR DESCRIPTION
Adds support for three new collections:
- KOTE Potions
- KOTE Rings
- KOTE Trinkets

All use the shared metadata subgraph