### PR TITLE
fix compare floor prices modal with extra metadata

### DIFF
--- a/src/pages/collection/[address]/index.tsx
+++ b/src/pages/collection/[address]/index.tsx
@@ -1055,6 +1055,28 @@ const Collection = ({ og }: { og: MetadataProps }) => {
     isTalesOfElleriaRelics ? listingIds : []
   );
 
+  const tokensWithStats = isTalesOfElleriaRelics
+    ? listings.data?.pages[0].tokens?.map((token) => {
+        const metadata = talesOfElleriaRelicsMetadata.data?.find(
+          (item) => parseInt(item.id) === parseInt(token.tokenId)
+        );
+        return {
+          ...token,
+          name: metadata?.name,
+        };
+      })
+    : isShared
+    ? listings.data?.pages[0].tokens?.map((token) => {
+        const metadata = sharedMetadata.data?.tokens.find(
+          (item) => item.tokenId === token.tokenId
+        );
+        return {
+          ...token,
+          name: metadata?.name,
+        };
+      })
+    : listings.data?.pages[0].tokens;
+
   const isLoading = React.useMemo(
     () =>
       [
@@ -1992,7 +2014,7 @@ const Collection = ({ og }: { og: MetadataProps }) => {
         <DetailedFloorPriceModal
           isOpen={true}
           onClose={() => setDetailedFloorPriceModalOpen(false)}
-          tokens={listings.data?.pages[0].tokens}
+          tokens={tokensWithStats}
         />
       )}
       {modalProps.isOpen && modalProps.targetNft && (


### PR DESCRIPTION
Fixes "Compare floor prices" modal for ERC1155 collections that get their metadata from another subgraph/API (e.g. Tales of Elleria Relics, Toadstoolz Itemz)

<img width="547" alt="Screen Shot 2022-05-29 at 9 57 24 AM" src="https://user-images.githubusercontent.com/1013230/170882264-274e2677-6e0b-4c51-866c-6a93a315a5b0.png">

