### PR TITLE
fix enchanting treasures filter

### DIFF
--- a/src/components/Filters.tsx
+++ b/src/components/Filters.tsx
@@ -61,7 +61,7 @@ const CATEGORY = [
   "Alchemy",
   "Arcana",
   "Brewing",
-  "Enchanter",
+  "Enchanting",
   "Leatherworking",
   "Smithing",
 ];


### PR DESCRIPTION
"Enchanter" Treasure category has been renamed to "Enchanting" on the subgraph. Updating here as well to fix the Treasures collection-level filters.