### PR TITLE
Fix Smithonia Weapons Filter

### DIFF
--- a/src/components/Filters.tsx
+++ b/src/components/Filters.tsx
@@ -467,6 +467,7 @@ export function useFiltersList() {
     isShared,
     isSmolverseItem,
     isSmithoniaWeaponsItem,
+    isTalesOfElleriaRelic,
     legacyAttributes.data?.collection?.attributes,
     smolverseAttributes.data?.attributes,
     sharedAttributes.data?.attributes,

--- a/src/pages/collection/[address]/index.tsx
+++ b/src/pages/collection/[address]/index.tsx
@@ -556,11 +556,11 @@ const Collection = ({ og }: { og: MetadataProps }) => {
       refetchInterval: false,
       select: React.useCallback(
         (data) => {
-          const itemsToHex = (items: number[]) => {
+          const itemsToHex = (items: number[]): string[] => {
             const hexxed = items.map((id) => `0x${id.toString(16)}`);
             return listedTokens.data?.filter((id) =>
               hexxed.some((hex) => id.endsWith(hex))
-            );
+            ) ?? [];
           };
 
           if (Array.isArray(data)) {

--- a/src/pages/collection/[address]/index.tsx
+++ b/src/pages/collection/[address]/index.tsx
@@ -555,12 +555,19 @@ const Collection = ({ og }: { og: MetadataProps }) => {
         isSmithonia,
       refetchInterval: false,
       select: React.useCallback(
-        (data: { items: number[] }) => {
-          const hexxed = data.items.map((id) => `0x${id.toString(16)}`);
+        (data) => {
+          const itemsToHex = (items: number[]) => {
+            const hexxed = items.map((id) => `0x${id.toString(16)}`);
+            return listedTokens.data?.filter((id) =>
+              hexxed.some((hex) => id.endsWith(hex))
+            );
+          };
 
-          return listedTokens.data?.filter((id) =>
-            hexxed.some((hex) => id.endsWith(hex))
-          );
+          if (Array.isArray(data)) {
+            return data.map((dataItem) => itemsToHex(dataItem.items)).flat();
+          } else {
+            return itemsToHex(data.items);
+          }
         },
         [listedTokens.data]
       ),


### PR DESCRIPTION
**Issue**
Selecting multiple SW Filters breaks the filter
![image](https://user-images.githubusercontent.com/62888804/171600218-899c15d9-d0b8-4ae5-a239-4758658cde94.png)


SW API returns an array when multiple filters are selected. The logic only handles single objects (this works for BattleFly)

![image](https://user-images.githubusercontent.com/62888804/171599828-a908b564-3901-4b6a-857a-b0d05b8b3e3c.png)


This PR implements a fix.

@wyze 