### PR TITLE
Point canonical urls to trove

### DIFF
--- a/src/components/Metadata.tsx
+++ b/src/components/Metadata.tsx
@@ -6,9 +6,16 @@ export type MetadataProps = {
   image: string;
   title: string;
   url: string;
+  canonicalUrl?: string;
 };
 
-export function Metadata({ description, url, image, ...props }: MetadataProps) {
+export function Metadata({
+  description,
+  url,
+  image,
+  canonicalUrl,
+  ...props
+}: MetadataProps) {
   const title = props.exactTitle
     ? props.title
     : `${props.title} | Treasure Marketplace`;
@@ -52,6 +59,8 @@ export function Metadata({ description, url, image, ...props }: MetadataProps) {
         href="https://fonts.gstatic.com"
         crossOrigin="true"
       />
+      {canonicalUrl && <link rel="canonical" href={canonicalUrl} />}
+
       {/* eslint-disable-next-line @next/next/no-page-custom-font */}
       <link
         href="https://fonts.googleapis.com/css2?family=Roboto+Mono&display=swap"

--- a/src/pages/collection/[address]/[tokenId].tsx
+++ b/src/pages/collection/[address]/[tokenId].tsx
@@ -1383,6 +1383,7 @@ export async function getServerSideProps(context: GetServerSidePropsContext) {
         image,
         title: `${tokenId} - ${collection}`,
         url: `https://marketplace.treasure.lol${context.resolvedUrl}`,
+        canonicalUrl: `https://trove.treasure.lol${context.resolvedUrl}`,
       },
     },
   };

--- a/src/pages/collection/[address]/index.tsx
+++ b/src/pages/collection/[address]/index.tsx
@@ -2153,6 +2153,7 @@ export async function getServerSideProps(context: GetServerSidePropsContext) {
         image,
         title,
         url: `https://marketplace.treasure.lol${context.resolvedUrl}`,
+        canonicalUrl: `https://trove.treasure.lol${context.resolvedUrl}`,
       },
     },
   };

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -41,6 +41,7 @@ export default function Home() {
         image="https://marketplace.treasure.lol/img/seoBanner.png"
         title="Treasure Marketplace, native to Arbitrum"
         url="https://marketplace.treasure.lol"
+        canonicalUrl="https://trove.treasure.lol"
       />
       <main className="flex flex-col mt-16 pt-20 w-full min-h-screen landing">
         <div className="z-10 px-8 max-w-2xl lg:max-w-7xl mx-auto">


### PR DESCRIPTION
Searching google for `smol brains` for example currently results in linking to the treasure  marketplace, this should help google point those pages to trove. 